### PR TITLE
Improve booksRouter supertest: add use case and clear mock afterEach

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -6,7 +6,6 @@ module.exports = {
   resolver: "jest-ts-webcompat-resolver",
   collectCoverageFrom: [
     "src/**/*.ts",
-    "!src/server/types.ts",
     "!src/index.ts",
     "!src/loadEnvironment.ts",
     "!src/database/connectToDataBase.ts",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,6 +11,6 @@ sonar.sourceEncoding=UTF-8
 
 sonar.test.inclusions=src/**/*.test.ts
 
-sonar.coverage.exclusions=src/index.tsx, src/loadEnvironment.ts,  src/database/connectToDataBase.ts  
+sonar.coverage.exclusions=src/index.tsx, src/loadEnvironment.ts, src/database/connectToDataBase.ts  
 
 sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/src/server/routers/books/booksRouter.test.ts
+++ b/src/server/routers/books/booksRouter.test.ts
@@ -20,10 +20,15 @@ afterAll(async () => {
   await server.stop();
 });
 
+afterEach(async () => {
+  await Book.deleteMany();
+});
+
 describe("Given a GET '/books' endopoint", () => {
   beforeEach(async () => {
     await Book.create(booksMock);
   });
+
   describe("When it receives a request", () => {
     test("Then it should call the response's method status with 200 and a collection of two books", async () => {
       const expectedStatusCode = statusCodes.ok;
@@ -33,6 +38,16 @@ describe("Given a GET '/books' endopoint", () => {
         .expect(expectedStatusCode);
 
       expect(response.body).toHaveLength(2);
+    });
+
+    test("Then it should respond with a collection of two books titled 'El desorden que dejas' and 'La ridícula idea de no volver a verte'", async () => {
+      const expectedTitle1 = booksMock[0].title;
+      const expectedTitle2 = booksMock[1].title;
+
+      const response = await request(app).get(`${paths.books}`);
+
+      expect(response.body[0].title).toBe(expectedTitle1);
+      expect(response.body[1].title).toBe(expectedTitle2);
     });
   });
 });

--- a/src/server/routers/books/booksRouter.ts
+++ b/src/server/routers/books/booksRouter.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import getBooks from "../../controllers/booksControllers/booksControllers";
+import getBooks from "../../controllers/booksControllers/booksControllers.js";
 
 const booksRouter = Router();
 


### PR DESCRIPTION
Mejorado super test booksRouter en dos ejes:
- Eliminando los Books creados después de cada test
- Añadiendo caso de uso que compruebe que, efectivamente, los libros devueltos por la base de datos del test son los esperados (a través de una propiedad única de cada libro --> título)