### PR TITLE
Feature/books router test

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,3 +16,6 @@ jobs:
 
       - name: 🧪 Testing
         run: npm test
+        env:
+          MONGODB_CONNECTION: ${{ secrets.MONGODB_CONNECTION }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}

--- a/src/mocks/booksMocks.ts
+++ b/src/mocks/booksMocks.ts
@@ -3,7 +3,7 @@ import { type BookDocumentStructure } from "../types/types";
 
 const booksMock: BookDocumentStructure[] = [
   {
-    _id: new Types.ObjectId(),
+    _id: new Types.ObjectId("647711a81beb7e30d69afe00"),
     title: "El desorden que dejas",
     author: "Carlos Montero",
     frontPage:

--- a/src/server/controllers/booksControllers/booksControllers.test.ts
+++ b/src/server/controllers/booksControllers/booksControllers.test.ts
@@ -82,7 +82,7 @@ describe("Given a deleteBook controller", () => {
       const expectedStatusCode = 200;
       const expectedMessage = messages.bookDeleted;
 
-      Book.findOne = jest.fn().mockReturnValue({
+      Book.findById = jest.fn().mockReturnValue({
         exec: jest.fn().mockResolvedValue(idBook),
       });
 
@@ -114,7 +114,7 @@ describe("Given a deleteBook controller", () => {
       const expectedStatusCode = 404;
       const expectedMessage = messages.errorDelete;
 
-      Book.findOne = jest.fn().mockReturnValue({
+      Book.findById = jest.fn().mockReturnValue({
         exec: jest.fn().mockResolvedValue(undefined),
       });
 

--- a/src/server/controllers/booksControllers/booksControllers.ts
+++ b/src/server/controllers/booksControllers/booksControllers.ts
@@ -41,13 +41,13 @@ export const deleteBook = async (
     const book = await Book.findById(id).exec();
 
     if (!book) {
-      res.status(404).json({ message: messages.errorDelete });
+      res.status(statusCodes.notFound).json({ message: messages.errorDelete });
       return;
     }
 
     await Book.findByIdAndDelete(id).exec();
 
-    res.status(200).json({ message: messages.bookDeleted });
+    res.status(statusCodes.ok).json({ message: messages.bookDeleted });
   } catch (error: unknown) {
     next(error);
   }

--- a/src/server/controllers/booksControllers/booksControllers.ts
+++ b/src/server/controllers/booksControllers/booksControllers.ts
@@ -38,7 +38,7 @@ export const deleteBook = async (
 ) => {
   const { id } = req.params;
   try {
-    const book = await Book.findOne({ id }).exec();
+    const book = await Book.findById(id).exec();
 
     if (!book) {
       res.status(404).json({ message: messages.errorDelete });


### PR DESCRIPTION
Añadidos casos de uso para el método DELETE en booksRouter.test

-  Que muestra un mensaje de éxito tras eliminar un libro que ha encontrado a través de su id
- Que muestra un mensaje de error tras no poder eliminar un libro porque la id es errónea