### PR TITLE
Refactor deleteBook controller to handle error in a more correct way

### DIFF
--- a/src/server/controllers/booksControllers/booksControllers.test.ts
+++ b/src/server/controllers/booksControllers/booksControllers.test.ts
@@ -109,19 +109,5 @@ describe("Given a deleteBook controller", () => {
 
       expect(next).toHaveBeenCalledWith(expectedError);
     });
-
-    test("Then it should call its status method with a status 404 and the response method with the message 'Can't delete this book because it doesn't exist' ", async () => {
-      const expectedStatusCode = 404;
-      const expectedMessage = messages.errorDelete;
-
-      Book.findById = jest.fn().mockReturnValue({
-        exec: jest.fn().mockResolvedValue(undefined),
-      });
-
-      await deleteBook(req as Request, res as Response, next);
-
-      expect(res.status).toHaveBeenCalledWith(expectedStatusCode);
-      expect(res.json).toHaveBeenCalledWith({ message: expectedMessage });
-    });
   });
 });

--- a/src/server/controllers/booksControllers/booksControllers.ts
+++ b/src/server/controllers/booksControllers/booksControllers.ts
@@ -41,8 +41,11 @@ export const deleteBook = async (
     const book = await Book.findById(id).exec();
 
     if (!book) {
-      res.status(statusCodes.notFound).json({ message: messages.errorDelete });
-      return;
+      const deleteError = new CustomError(
+        `${messages.errorDelete}`,
+        statusCodes.notFound
+      );
+      throw deleteError;
     }
 
     await Book.findByIdAndDelete(id).exec();


### PR DESCRIPTION
Refactorización del controller deleteBook para manejar el error de id no encontrada de una forma más correcta.

Fruto de esta refactorización, se elimina caso de uso innecesario en la suit booksControllers.test