### PR TITLE
Add test cases for POST method in booksRouter.test

### DIFF
--- a/src/server/controllers/booksControllers/booksControllers.test.ts
+++ b/src/server/controllers/booksControllers/booksControllers.test.ts
@@ -128,7 +128,7 @@ describe("Given a addBook controller", () => {
       const expectedStatusCode = statusCodes.created;
       const expectedMessage = messages.bookAdded;
       const expectedResult = {
-        messages: expectedMessage,
+        message: expectedMessage,
         addedBook: addBookMock,
       };
 

--- a/src/server/controllers/booksControllers/booksControllers.ts
+++ b/src/server/controllers/booksControllers/booksControllers.ts
@@ -72,7 +72,7 @@ export const addBook = async (
 
     res
       .status(statusCodes.created)
-      .json({ messages: messages.bookAdded, addedBook });
+      .json({ message: messages.bookAdded, addedBook });
   } catch (error: unknown) {
     (error as Error).message = messages.errorAdd;
     next(error);

--- a/src/server/routers/books/booksRouter.test.ts
+++ b/src/server/routers/books/booksRouter.test.ts
@@ -8,6 +8,7 @@ import statusCodes from "../../utils/statusCodes/statusCodes";
 import { app } from "../..";
 import paths from "../../utils/paths/paths.js";
 import messages from "../../utils/messages/messages";
+import { addBookMock } from "../../../mocks/booksMocks.js";
 
 let server: MongoMemoryServer;
 
@@ -82,6 +83,40 @@ describe("Given a DELETE '/books/delete/:id' endpoint", () => {
 
         expect(response.body.message).toBe(expectedMessage);
       });
+    });
+  });
+});
+
+describe("Given a POST '/books/add' endpoint", () => {
+  describe("When it receives a valid book in the body's request", () => {
+    test("Then it should call the response's method status with 201, the message 'The book has been created' and the new book created", async () => {
+      const expectedStatusCode = statusCodes.created;
+
+      const expectedNewBookProperty = "addedBook";
+      const expectedMessageProperty = "message";
+
+      const response = await request(app)
+        .post(`${paths.books}/add`)
+        .send(addBookMock)
+        .expect(expectedStatusCode);
+
+      expect(response.body).toHaveProperty(expectedNewBookProperty);
+      expect(response.body).toHaveProperty(expectedMessageProperty);
+    });
+  });
+
+  describe("When it receives an invalid book in the body's request, as a book without author required property", () => {
+    test("Then it should call the response's method '400' and the message 'author is not allowed to be empty'", async () => {
+      const expectedStatusCode = statusCodes.badRequest;
+      const expectedMessage = "author is not allowed to be empty";
+      addBookMock.author = "";
+
+      const response = await request(app)
+        .post(`${paths.books}/add`)
+        .send(addBookMock)
+        .expect(expectedStatusCode);
+
+      expect(response.body.message).toBe(expectedMessage);
     });
   });
 });


### PR DESCRIPTION
Añadidos casos de uso a la suite booksRouter.test para contemplar el método POST:
- Que en el body de la response aparecen dos nuevas propiedades: “addedBook” (apunta al nuevo libro añadido) “ y “message” (que apunta a un mensaje de éxito al haber creado el libro)
- Que  se ejecuta correctamente la validación de Joi cuando se introduce un libro inválido (por faltarle alguno de sus campos requeridos)