### PR TITLE
Add functionality to fetch books by descending id from the api

### DIFF
--- a/src/server/controllers/booksControllers/booksControllers.test.ts
+++ b/src/server/controllers/booksControllers/booksControllers.test.ts
@@ -24,6 +24,7 @@ describe("Given a getBooks controller", () => {
   const next = jest.fn();
   describe("When it receives a request", () => {
     Book.find = jest.fn().mockReturnValue({
+      sort: jest.fn().mockReturnThis(),
       limit: jest.fn().mockReturnValue({
         exec: jest.fn().mockResolvedValue(booksMock),
       }),
@@ -124,7 +125,7 @@ describe("Given a addBook controller", () => {
   const next = jest.fn();
 
   describe("When it receives a request with a valid book on its body, a response and a next function", () => {
-    test("Then it should calls the response's method with status code '201' the message 'The book has been created' and the book create", async () => {
+    test("Then it should calls the response's method with status code '201' the message 'The book has been created' and the book created", async () => {
       const expectedStatusCode = statusCodes.created;
       const expectedMessage = messages.bookAdded;
       const expectedResult = {

--- a/src/server/controllers/booksControllers/booksControllers.ts
+++ b/src/server/controllers/booksControllers/booksControllers.ts
@@ -21,7 +21,7 @@ export const getBooks = async (
   next: NextFunction
 ) => {
   try {
-    const myBooks = await Book.find().limit(10).exec();
+    const myBooks = await Book.find().sort({ _id: -1 }).limit(10).exec();
 
     res.status(200).json(myBooks);
   } catch {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -11,6 +11,7 @@ import booksRouter from "./routers/books/booksRouter.js";
 const allowedOrigins = [
   process.env.ALLOWED_ORIGIN_DEV!,
   process.env.ALLOWED_ORIGIN_PROD!,
+  process.env.ALLOWED_ORIGIN_PREVIEW!,
 ];
 
 const options: cors.CorsOptions = {

--- a/src/server/routers/books/booksRouter.test.ts
+++ b/src/server/routers/books/booksRouter.test.ts
@@ -48,8 +48,8 @@ describe("Given a GET '/books' endopoint", () => {
 
       const response = await request(app).get(`${paths.books}`);
 
-      expect(response.body[0].title).toBe(expectedTitle1);
-      expect(response.body[1].title).toBe(expectedTitle2);
+      expect(response.body[1].title).toBe(expectedTitle1);
+      expect(response.body[0].title).toBe(expectedTitle2);
     });
   });
 });

--- a/src/server/utils/Schemas/addBookSchema.ts
+++ b/src/server/utils/Schemas/addBookSchema.ts
@@ -11,7 +11,7 @@ const addBookSchema = {
     status: Joi.boolean().required(),
     rating: Joi.number(),
     destination: Joi.string().required(),
-    cosmos: Joi.string(),
+    cosmos: Joi.string().allow(""),
   }),
 };
 


### PR DESCRIPTION
Añadida funcionalidad en controller getBooks para que traiga los libros desde la base de datos ordenados por id descendente, de manera que así, al crear un libro nuevo aparezca en la parte superior de la interface para el usuario.
Reparados los test afectados con esta nueva funcionalidad.

Se ha refactorizado la propiedad cosmos del BookSchema para evitar un error de validación en aquellos casos en los que se quiera añadir un libro con este campo vacío.

Añadido un nuevo allowedOrigin para que CORS permita acceso al entorno de producción "preview"